### PR TITLE
Scrum 217 & Possible Others Defining and routing the endpoints from the microservice through the API gateway to the main site on the gateway.

### DIFF
--- a/APIGateway/APIGateway.csproj
+++ b/APIGateway/APIGateway.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Caching.Distributed;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using System.Net.Http;
 
 namespace Gateway
 {
@@ -54,6 +55,15 @@ namespace Gateway
 
         };
 
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        private readonly HttpClient client;
+        private readonly ILogger<GatewayController> _logger;
+
         public async Task<GameInfo[]> GetGamesAsync()
         {
             try
@@ -73,14 +83,28 @@ namespace Gateway
             return new GameInfo[] { };
         }
 
-        private readonly JsonSerializerOptions options = new JsonSerializerOptions()
+        /*
+        public async Task GetGamesWithInfo()
         {
-            PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
+            GameInfo[] gameInfos = await GetGamesAsync();
 
-        private readonly HttpClient client;
-        private readonly ILogger<GatewayController> _logger;
+            TheInfo
+            foreach (Game game in games)
+            {
+                GameInfo info = gameInfos.FirstOrDefault(x => x.Title == game.Title);
+                if (info != null)
+                {
+                    game.Author = info.Author;
+                    game.HowTo = info.HowTo;
+                    game.DateAdded = info.DateAdded;
+                    game.Description = $"{info.Description} \n {info.DateAdded}";
+                    game.LeaderBoard = info.LeaderBoard;
+                }
+            }
+
+            return games;
+        }
+        */
 
         public GatewayController(ILogger<GatewayController> logger)
         {

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -24,7 +24,7 @@ namespace Gateway
                 Author = "Failed to retrieve from Microservice",
                 DateAdded = "",
                 Description = "Failed to retrieve from Microservice",
-                HowTo = "Control with arrow keys.",
+                HowTo = "Failed to retrieve from Microservice",
                 //Thumbnail = "/images/snake.jpg" //640x360 resolution
                 LeaderBoardStack = new Stack<KeyValuePair<string, int>>(),
 
@@ -36,6 +36,7 @@ namespace Gateway
                 Author = "Failed to retrieve from Microservice",
                 DateAdded = "",
                 Description = "Failed to retrieve from Microservice",
+                HowTo = "Failed to retrieve from Microservice",
                 //Thumbnail = "/images/tetris.jpg"
                 LeaderBoardStack = new Stack<KeyValuePair<string, int>>(),
                 

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 using Microsoft.Extensions.Caching.Distributed;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 
 namespace Gateway
 {
@@ -53,6 +54,25 @@ namespace Gateway
             },
 
         };
+
+        public async Task<GameInfo[]> GetGamesAsync()
+        {
+            try
+            {
+                var responseMessage = await this.client.GetAsync("/Micro");
+
+                if (responseMessage != null)
+                {
+                    var stream = await responseMessage.Content.ReadAsStreamAsync();
+                    return await JsonSerializer.DeserializeAsync<GameInfo[]>(stream, options);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex.Message);
+            }
+            return new GameInfo[] { };
+        }
 
         private readonly ILogger<GatewayController> _logger;
 

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -19,11 +19,11 @@ namespace Gateway
         {
             new GameInfo { 
                 //Id = 1,
-                Title = "Snake",
+                Title = "Failed to retrieve from Microservice",
                 //Content = "~/js/snake.js",
-                Author = "Fall 2023 Semester",
+                Author = "Failed to retrieve from Microservice",
                 DateAdded = "",
-                Description = "Snake is a classic arcade game that challenges the player to control a snake-like creature that grows longer as it eats apples. The player must avoid hitting the walls or the snake's own body, which can end the game.\r\n",
+                Description = "Failed to retrieve from Microservice",
                 HowTo = "Control with arrow keys.",
                 //Thumbnail = "/images/snake.jpg" //640x360 resolution
                 LeaderBoardStack = new Stack<KeyValuePair<string, int>>(),
@@ -31,24 +31,23 @@ namespace Gateway
     },
             new GameInfo { 
                 //Id = 2,
-                Title = "Tetris",
+                Title = "Failed to retrieve from Microservice",
                 //Content = "~/js/tetris.js",
-                Author = "Fall 2023 Semester",
+                Author = "Failed to retrieve from Microservice",
                 DateAdded = "",
-                Description = "Tetris is a classic arcade puzzle game where the player has to arrange falling blocks, also known as Tetronimos, of different shapes and colors to form complete rows on the bottom of the screen. The game gets faster and harder as the player progresses, and ends when the Tetronimos reach the top of the screen.",
-                HowTo = "Control with arrow keys: Up arrow to spin, down to speed up fall, space to insta-drop.",
+                Description = "Failed to retrieve from Microservice",
                 //Thumbnail = "/images/tetris.jpg"
                 LeaderBoardStack = new Stack<KeyValuePair<string, int>>(),
                 
             },
             new GameInfo { 
                 //Id = 3,
-                Title = "Pong",
+                Title = "Failed to retrieve from Microservice",
                 //Content = "~/js/pong.js",
-                Author = "Fall 2023 Semester",
+                Author = "Failed to retrieve from Microservice",
                 DateAdded = "",
-                Description = "Pong is a classic arcade game where the player uses a paddle to hit a ball against a computer's paddle. Either party scores when the ball makes it past the opponent's paddle.",
-                HowTo = "Control with arrow keys.",
+                Description = "Failed to retrieve from Microservice",
+                HowTo = "Failed to retrieve from Microservice",
                 //Thumbnail = "/images/pong.jpg"
                 LeaderBoardStack = new Stack<KeyValuePair<string, int>>(),
             },

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -19,7 +19,7 @@ namespace Gateway
         {
             new GameInfo { 
                 //Id = 1,
-                Title = "Snake",
+                Title = "Failed to retrive title from microservice",
                 //Content = "~/js/snake.js",
                 Author = "Fall 2023 Semester",
                 DateAdded = "",
@@ -74,6 +74,13 @@ namespace Gateway
             return new GameInfo[] { };
         }
 
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        private readonly HttpClient client;
         private readonly ILogger<GatewayController> _logger;
 
         public GatewayController(ILogger<GatewayController> logger)

--- a/APIGateway/Controllers/GatewayController.cs
+++ b/APIGateway/Controllers/GatewayController.cs
@@ -8,12 +8,15 @@ using System.Net.Http.Json;
 
 namespace Gateway
 {
+    /// <summary>
+    /// Controller responsible for handling requests and responses at the gateway.
+    /// </summary>
     [ApiController]
     [Route("[controller]")]
     public class GatewayController : ControllerBase
     {
-        private readonly HttpClient _httpClient;
-        private readonly ILogger<GatewayController> _logger;
+        private readonly HttpClient _httpClient; // Making readonly ensures thread safety 
+        private readonly ILogger<GatewayController> _logger; // Making readonly ensures thread safety 
 
         public GatewayController(HttpClient httpClient, ILogger<GatewayController> logger)
         {
@@ -21,13 +24,17 @@ namespace Gateway
             _logger = logger;
         }
 
+        /// <summary>
+        /// Handles GET requests to retrieve game information from the microservice.
+        /// </summary>
+        /// <returns>A collection of GameInfo objects.</returns>
         [HttpGet]
         public async Task<IEnumerable<GameInfo>> Get()
         {
             try
             {
                 // Make a GET request to the microservice's endpoint
-                HttpResponseMessage response = await _httpClient.GetAsync("https://localhost:7223/Micro");
+                HttpResponseMessage response = await _httpClient.GetAsync("https://localhost:7223/Micro"); // URL might need to change for deployment 
 
                 // Check if the request was successful
                 if (response.IsSuccessStatusCode)
@@ -51,8 +58,16 @@ namespace Gateway
             }
         }
 
+        /// <summary>
+        /// Generates a placeholder list of GameInfo objects indicating failure to retrieve data.
+        /// </summary>
+        /// <returns>A collection of GameInfo objects indicating failure.</returns>
         private IEnumerable<GameInfo> GenerateFailureResponse()
         {
+            // Using IEnumerable allows flexibility in returning a placeholder response.
+            // It allows the method to return different types of collections (e.g., List, Array) if needed in the future.
+            // In this case, IEnumerable provides a simple way to return a list of failed responses.
+
             // Generate a placeholder list of GameInfo objects indicating failure to retrieve data
             return new List<GameInfo>
             {
@@ -62,7 +77,7 @@ namespace Gateway
                     Author = "Failed to retrieve from Microservice",
                     Description = "Failed to retrieve from Microservice",
                     HowTo = "Failed to retrieve from Microservice",
-                    LeaderBoardStack = new Stack<KeyValuePair<string, int>>()
+                    LeaderBoardStack = new Stack<KeyValuePair<string, int>>() // Initializing an empty stack
                 }
             };
         }

--- a/APIGateway/Program.cs
+++ b/APIGateway/Program.cs
@@ -7,6 +7,9 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Register HttpClient
+builder.Services.AddHttpClient();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/APIGateway/Properties/launchSettings.json
+++ b/APIGateway/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:7223;http://localhost:5130"
+      "applicationUrl": "https://localhost:4141"
     },
     "IIS Express": {
       "commandName": "IISExpress",


### PR DESCRIPTION
So I used ChatGPT to create a method call to read the game info from the microserver. If the call fails it returns a game info object with failed messages for strings. However, the failed game info object never shows up on bucstop because of the game title comparison, so that code is kinda pointless, but could be changed to another failed message somewhere else. The logger gets update with the failed messages. If you have any questions ask and I might be able to help. 